### PR TITLE
Added css flags to make showing/hiding els conditional on a test easier

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -267,10 +267,20 @@ Experiments.prototype.run = function () {
     var belongsTo = this.getParticipation().variant;
     this.profile.variants.forEach(function (v) {
         if (v.id === belongsTo) {
+            this.setCssFlag(this.opts.id, v.id); 
             v.test.call();
         }
     });
     return this;
+};
+
+/** 
+ * Run the AB test
+ * @return {Object} 
+ */
+Experiments.prototype.setCssFlag = function (test, variant) {
+    "use strict";
+    document.documentElement.className += ' ' + test ':' + variant
 };
 
 /** 


### PR DESCRIPTION
In css can't use a class selector but can use `html[class*="test:variant"]`. Worth having experiments set a `data-experiments` attribute on html instead and then use `html[data-experiments*="test:variant"]`?
